### PR TITLE
fix(backend program):兼容cedar2025写的后端

### DIFF
--- a/app/Http/Controllers/Server/UniProxyController.php
+++ b/app/Http/Controllers/Server/UniProxyController.php
@@ -118,7 +118,7 @@ class UniProxyController extends Controller
                     'server_name' => $this->nodeInfo->server_name,
                     'up_mbps' => $this->nodeInfo->up_mbps,
                     'down_mbps' => $this->nodeInfo->down_mbps,
-                    'obfs' => Helper::getServerKey($this->nodeInfo->created_at, 16)
+                    #'obfs' => Helper::getServerKey($this->nodeInfo->created_at, 16)
                 ];
                 break;
         }


### PR DESCRIPTION
使用cedar2025写的后端程序会读取obfs设置，使客户端配置不一致